### PR TITLE
Rename open-cluster-management org refs to stolostron [2.3]

### DIFF
--- a/.github/workflows/trigger-installer.yml
+++ b/.github/workflows/trigger-installer.yml
@@ -18,7 +18,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v1.1.3
         with:
           token: ${{ secrets.HUB_OPERATOR_TOKEN }}
-          repository: open-cluster-management/multiclusterhub-operator
+          repository: stolostron/multiclusterhub-operator
           event-type: crd-change
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}"}'
           

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ contribution. See the [DCO](DCO) file for details.
 
 ## DCO Sign Off
 
-You must sign off your commit to state that you certify the [DCO](https://github.com/open-cluster-management/community/blob/main/DCO). To certify your commit for DCO, add a line like the following at the end of your commit message:
+You must sign off your commit to state that you certify the [DCO](https://github.com/open-cluster-management-io/community/blob/main/DCO). To certify your commit for DCO, add a line like the following at the end of your commit message:
 
 ```
 Signed-off-by: John Smith <john@example.com>

--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ We are in the process of enabling this repo for community contribution. See wiki
 
 # MultiClusterHub CRDs
 
-Central location for CRDs used by Multiclusterhub components. This repo provides CRDs for the [multiclusterhub-operator installer](https://github.com/open-cluster-management/multiclusterhub-operator). Updating CRDs in this repo will trigger an update in the installer repo to point to the latest version.
+Central location for CRDs used by Multiclusterhub components. This repo provides CRDs for the [multiclusterhub-operator installer](https://github.com/stolostron/multiclusterhub-operator). Updating CRDs in this repo will trigger an update in the installer repo to point to the latest version.
 
 ## CRD chart sources
 Original locations of CRDs
 
-https://github.com/open-cluster-management/rcm-chart
+https://github.com/stolostron/rcm-chart
 - agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 
-https://github.com/open-cluster-management/cluster-lifecycle-chart
+https://github.com/stolostron/cluster-lifecycle-chart
 - cluster.open-cluster-management.io_clustercurators.yaml
 
-https://github.com/open-cluster-management/grc-chart
+https://github.com/stolostron/grc-chart
 - policy.open-cluster-management.io_placementbindings_crd.yaml
 - policy.open-cluster-management.io_policies_crd.yaml
 
-https://github.com/open-cluster-management/search-chart
+https://github.com/stolostron/search-chart
 - search.open-cluster-management.io_searchcustomizations.yaml
 - search.open-cluster-management.io_searchoperators.yaml
 
-https://github.com/open-cluster-management/console-chart
+https://github.com/stolostron/console-chart
 - user-preference-crd.yaml
 
-https://github.com/open-cluster-management/multiclusterhub-operator (foundation/OCM)
+https://github.com/stolostron/multiclusterhub-operator (foundation/OCM)
 - view.open-cluster-management.io_managedclusterviews_crd.yaml
 - internal.open-cluster-management.io_managedclusterinfos_crd.yaml
 - inventory.open-cluster-management.io_baremetalassets_crd.yaml


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/18704

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>